### PR TITLE
Add a linear IRL example (VI and PI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@
 
 ## References
 [1] F. L. Lewis, D. Vrabie, and K. G. Vamvoudakis, “Reinforcement Learning and Feedback Control: Using Natural Decision Methods to Design Optimal Adaptive Controllers,” IEEE Control Syst., vol. 32, no. 6, pp. 76–105, Dec. 2012, doi: 10.1109/MCS.2012.2214134.
-[2] D. Vrabie, O. Pastravanu, M. Abu-Khalaf, and F. L. Lewis, “Adaptive Optimal Control for Continuous-Time Linear Systems Based on Policy Iteration,” Automatica, vol. 45, no. 2, pp. 477–484, Feb. 2009, doi: 10.1016/j.automatica.2008.08.017.
 
+[2] D. Vrabie, O. Pastravanu, M. Abu-Khalaf, and F. L. Lewis, “Adaptive Optimal Control for Continuous-Time Linear Systems Based on Policy Iteration,” Automatica, vol. 45, no. 2, pp. 477–484, Feb. 2009, doi: 10.1016/j.automatica.2008.08.017.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # DataDrivenControl
+
+## Algorithms
+### Integral Reinforcement Learning (IRL)
+- `LinearIRL`: IRL algorithm for affine dynamics and quadratic cost (in control input)
+    - Update methods
+        1. `policy_iteration!` [1, Eqs. (98), (96)], [2]
+        2. `value_iteration!` [1, Eqs. (99), (96)]
+
+
+## References
+[1] F. L. Lewis, D. Vrabie, and K. G. Vamvoudakis, “Reinforcement Learning and Feedback Control: Using Natural Decision Methods to Design Optimal Adaptive Controllers,” IEEE Control Syst., vol. 32, no. 6, pp. 76–105, Dec. 2012, doi: 10.1109/MCS.2012.2214134.
+[2] D. Vrabie, O. Pastravanu, M. Abu-Khalaf, and F. L. Lewis, “Adaptive Optimal Control for Continuous-Time Linear Systems Based on Policy Iteration,” Automatica, vol. 45, no. 2, pp. 477–484, Feb. 2009, doi: 10.1016/j.automatica.2008.08.017.
+

--- a/main/linear_irl.jl
+++ b/main/linear_irl.jl
@@ -50,7 +50,7 @@ function main()
         w_true = [P_true[1, 1], P_true[2, 1]+P_true[1, 2], P_true[2, 2]]
         scale = 0.1
         w0 = w_true + scale*randn(3)  # perturbed initial guess
-        tf = 10.0
+        tf = 5.0
         simulator = Simulator(x0, Dynamics!(env), w0;
                               tf=tf,
                              )
@@ -67,8 +67,8 @@ function main()
                   t=t, x=copy(x), u=copy(u), w=copy(w))
             eps = 1e-1
             sc = DistanceStopCondition(eps)
-            value_iteration!(controller, buffer, w; sc=sc)
-            # policy_iteration!(controller, buffer, w; sc=sc)
+            # value_iteration!(controller, buffer, w; sc=sc)
+            policy_iteration!(controller, buffer, w; sc=sc)
         end
         cb_irl = PeriodicCallback(update!, controller.T; initial_affect=true)  # stack initial data
         df = solve(simulator;

--- a/main/linear_irl.jl
+++ b/main/linear_irl.jl
@@ -64,7 +64,7 @@ function main()
             u = optimal_input(controller, x, w)  # TODO: not to be duplicate of control input in dynamics for stable coding
             push!(buffer, controller, cost;
                   t=t, x=copy(x), u=copy(u), w=copy(w))
-            evaluate_policy!(controller, buffer, w)
+            value_iteration!(controller, buffer, w)
         end
         cb_irl = PeriodicCallback(update!, controller.T; initial_affect=true)  # stack initial data
         df = solve(simulator;

--- a/main/linear_irl.jl
+++ b/main/linear_irl.jl
@@ -64,7 +64,8 @@ function main()
             u = optimal_input(controller, x, w)  # TODO: not to be duplicate of control input in dynamics for stable coding
             push!(buffer, controller, cost;
                   t=t, x=copy(x), u=copy(u), w=copy(w))
-            value_iteration!(controller, buffer, w)
+            # value_iteration!(controller, buffer, w)
+            policy_iteration!(controller, buffer, w)
         end
         cb_irl = PeriodicCallback(update!, controller.T; initial_affect=true)  # stack initial data
         df = solve(simulator;

--- a/main/linear_irl.jl
+++ b/main/linear_irl.jl
@@ -57,9 +57,9 @@ function main()
         xs = df.sol |> Map(datum -> datum.state) |> collect
         us = df.sol |> Map(datum -> datum.input) |> collect
         ws = df.sol |> Map(datum -> datum.param) |> collect
-        fig_x = plot(hcat(xs...)'; label=[L"x_{1}" L"x_{2}"])
-        fig_u = plot(hcat(us...)'; label=L"u")
-        fig_w = plot(hcat(ws...)'; label=[L"w_{1}" L"w_{2}" L"w_{3}"])
+        fig_x = plot(ts, hcat(xs...)'; label=[L"x_{1}" L"x_{2}"])
+        fig_u = plot(ts, hcat(us...)'; label=L"u")
+        fig_w = plot(ts, hcat(ws...)'; label=[L"w_{1}" L"w_{2}" L"w_{3}"])
         fig = plot(fig_x, fig_u, fig_w)
 
 

--- a/main/linear_irl.jl
+++ b/main/linear_irl.jl
@@ -1,0 +1,81 @@
+using DataDrivenControl
+using FlightSims
+using UnPack
+using Plots
+using LinearAlgebra
+using Transducers
+using LaTeXStrings
+
+
+struct LinearSystem_ZOH_Gain
+    linear::LinearSystem
+    controller::LinearIRL
+end
+
+function FlightSims.State(env::LinearSystem_ZOH_Gain)
+    @unpack linear = env
+    State(linear)
+end
+
+function FlightSims.Dynamics!(env::LinearSystem_ZOH_Gain)
+    @unpack linear, controller = env
+    @Loggable function dynamics!(dx, x, w, t)
+        u = optimal_input(controller, x, w)
+        @onlylog param = w
+        @nested_log Dynamics!(linear)(dx, x, w, t; u=u)
+    end
+end
+
+# See [1, Example 2. Continuous-Time Optimal Adaptive Control Using IRL]
+# Refs
+# [1] “Reinforcement Learning and Feedback Control: Using Natural Decision Methods to Design Optimal Adaptive Controllers,” IEEE Control Syst., vol. 32, no. 6, pp. 76–105, Dec. 2012, doi: 10.1109/MCS.2012.2214134.
+function main()
+        n, m = 2, 1
+        A = [   -10  1;
+             -0.002 -2]
+        B = [0 2]'
+        Q = Matrix(I, n, n)
+        R = Matrix(I, m, m)
+        cost = DataDrivenControl.QuadraticCost(Q, R)
+        linear = LinearSystem(A, B)
+        controller = DataDrivenControl.LinearIRL(Q, R, B)
+        env = LinearSystem_ZOH_Gain(linear, controller)
+        x0 = State(env)(rand(2))
+        # TODO: add callback to update param `w`
+        # simulation
+        P = [0.0500 0.0039;
+             0.0039 0.2085]  # true solution
+        w = [P[1, 1], P[2, 1]+P[1, 2], P[2, 2]]  # true solution
+        tf = 10.0
+        simulator = Simulator(x0, Dynamics!(env), w;
+                              tf=tf,
+                             )
+        Δt = controller.T
+        df = solve(simulator; savestep=Δt)
+        # plot
+        ts = df.time
+        xs = df.sol |> Map(datum -> datum.state) |> collect
+        us = df.sol |> Map(datum -> datum.input) |> collect
+        ws = df.sol |> Map(datum -> datum.param) |> collect
+        fig_x = plot(hcat(xs...)'; label=[L"x_{1}" L"x_{2}"])
+        fig_u = plot(hcat(us...)'; label=L"u")
+        fig_w = plot(hcat(ws...)'; label=[L"w_{1}" L"w_{2}" L"w_{3}"])
+        fig = plot(fig_x, fig_u, fig_w)
+
+
+        # # data buffer
+        # buffer = DataDrivenControl.DataBuffer()
+        # # TODO
+        # ts = 0:irl.T:1
+        # for t in ts
+        #     push!(buffer, irl, cost; t=t, x=x, u=û, w=ŵ)
+        # end
+        # @test length(buffer.data_array) == length(ts)
+        # ŵ_new = deepcopy(ŵ)
+        # i = deepcopy(irl.i)
+        # DataDrivenControl.evaluate_policy!(irl, buffer, ŵ_new)
+        # @test ŵ_new != ŵ  # updated?
+        # @test i + 1 == irl.i
+        # DataDrivenControl.reset!(irl)
+        # @test irl.i == irl.i_init
+end

--- a/src/DataDrivenControl.jl
+++ b/src/DataDrivenControl.jl
@@ -11,6 +11,9 @@ export QuadraticInInputCost, QuadraticCost
 export LinearIRL, value_iteration!, policy_iteration!
 export optimal_input
 
+## Stop conditions
+export DistanceStopCondition
+
 
 include("utils/utils.jl")
 include("irl/irl.jl")

--- a/src/DataDrivenControl.jl
+++ b/src/DataDrivenControl.jl
@@ -8,7 +8,7 @@ using Transducers
 export QuadraticInInputCost, QuadraticCost
 ## IRL
 # Linear IRL
-export LinearIRL, evaluate_policy!
+export LinearIRL, value_iteration!
 export optimal_input
 
 

--- a/src/DataDrivenControl.jl
+++ b/src/DataDrivenControl.jl
@@ -6,7 +6,9 @@ using Transducers
 
 ## Costs
 export QuadraticInInputCost, QuadraticCost
-export LinearIRL
+## IRL
+# Linear IRL
+export LinearIRL, evaluate_policy!
 export optimal_input
 
 

--- a/src/DataDrivenControl.jl
+++ b/src/DataDrivenControl.jl
@@ -6,6 +6,8 @@ using Transducers
 
 ## Costs
 export QuadraticInInputCost, QuadraticCost
+export LinearIRL
+export optimal_input
 
 
 include("utils/utils.jl")

--- a/src/DataDrivenControl.jl
+++ b/src/DataDrivenControl.jl
@@ -8,7 +8,7 @@ using Transducers
 export QuadraticInInputCost, QuadraticCost
 ## IRL
 # Linear IRL
-export LinearIRL, value_iteration!
+export LinearIRL, value_iteration!, policy_iteration!
 export optimal_input
 
 

--- a/src/irl/linear_irl.jl
+++ b/src/irl/linear_irl.jl
@@ -34,12 +34,13 @@ mutable struct LinearIRL <: AbstractIRL
         @assert T > 0 && N > 0
         n1, n2 = size(Q)
         @assert n1 == n2
-        N_min = n1*(n1 + 1)/2
+        N_min = Int(n1*(n1 + 1)/2)
         if N == nothing
             N = N_min
         else
             @assert N >= N_min
         end
+        @assert T > 0 && N > 0
         R_inv = inv(R)
         i = i_init
         new(Q, R_inv, B, T, N, i, i_init)

--- a/src/irl/linear_irl.jl
+++ b/src/irl/linear_irl.jl
@@ -59,7 +59,7 @@ w: critic parameter (vectorised)
 - V̂: the vector of approximate values (evaluated)
 """
 function value_iteration!(irl::LinearIRL, buffer::DataBuffer, w;
-        sc::AbstractStopCondition=DistanceStopCondition(eps),
+        sc::AbstractStopCondition=DistanceStopCondition(),
     )
     @unpack i, N = irl
     @unpack data_array = buffer
@@ -94,7 +94,7 @@ w: critic parameter (vectorised)
 - ∫rs: the vector of integral running cost by numerical integration (evaluated)
 """
 function policy_iteration!(irl::LinearIRL, buffer::DataBuffer, w;
-        sc::AbstractStopCondition=DistanceStopCondition(eps),
+        sc::AbstractStopCondition=DistanceStopCondition(),
     )
     @unpack i, N = irl
     @unpack data_array = buffer

--- a/src/irl/linear_irl.jl
+++ b/src/irl/linear_irl.jl
@@ -16,6 +16,7 @@ mutable struct LinearIRL <: AbstractIRL
     N::Int
     i::Int
     i_init::Int
+    stopped::Bool
     function LinearIRL(Q::AbstractMatrix, R::AbstractMatrix, B::AbstractMatrix;
             T=0.04,
             N=nothing,
@@ -41,7 +42,8 @@ mutable struct LinearIRL <: AbstractIRL
         @assert T > 0 && N > 0
         R_inv = inv(R)
         i = i_init
-        new(Q, R_inv, B, T, N, i, i_init)
+        stopped = false
+        new(Q, R_inv, B, T, N, i, i_init, stopped)
     end
 end
 
@@ -56,7 +58,9 @@ w: critic parameter (vectorised)
 - ϕs_prev: the vector of bases (evaluated)
 - V̂: the vector of approximate values (evaluated)
 """
-function value_iteration!(irl::LinearIRL, buffer::DataBuffer, w)
+function value_iteration!(irl::LinearIRL, buffer::DataBuffer, w;
+        sc::AbstractStopCondition=DistanceStopCondition(eps),
+    )
     @unpack i, N = irl
     @unpack data_array = buffer
     data_filtered = filter(x -> x.i == i, data_array)  # data from the current policy
@@ -70,9 +74,15 @@ function value_iteration!(irl::LinearIRL, buffer::DataBuffer, w)
         V̂s_with_prev_P = xs |> Map(x -> value(irl, P, x)) |> collect
         V̂s = ∫rs .+ V̂s_with_prev_P
         # update the critic parameter
-        w .= ( hcat(V̂s...) * pinv(hcat(ϕs_prev...)) )'[:]  # to reduce the computation time; [:] for vectorisation
-        # w .= pinv(hcat(ϕs_prev...)') * hcat(V̂s...)'  # least square sense
-        update_index!(irl)
+        w_new = ( hcat(V̂s...) * pinv(hcat(ϕs_prev...)) )'[:]  # to reduce the computation time; [:] for vectorisation
+        if !irl.stopped
+            if is_stopped(sc, w, w_new)
+                irl.stopped = true
+            else
+                w .= w_new
+                update_index!(irl)
+            end
+        end
     end
 end
 
@@ -83,7 +93,9 @@ w: critic parameter (vectorised)
 - Δϕs: the vector of (ϕ - ϕ_prev) (evaluated)
 - ∫rs: the vector of integral running cost by numerical integration (evaluated)
 """
-function policy_iteration!(irl::LinearIRL, buffer::DataBuffer, w)
+function policy_iteration!(irl::LinearIRL, buffer::DataBuffer, w;
+        sc::AbstractStopCondition=DistanceStopCondition(eps),
+    )
     @unpack i, N = irl
     @unpack data_array = buffer
     data_filtered = filter(x -> x.i == i, data_array)  # data from the current policy
@@ -93,9 +105,15 @@ function policy_iteration!(irl::LinearIRL, buffer::DataBuffer, w)
         Δϕs = diff(ϕs_prev_and_present)
         ∫rs = data_sorted[end-(N-1):end] |> Map(datum -> datum.∫r) |> collect
         # update the critic parameter
-        w .= ( hcat(∫rs...) * pinv(hcat(-Δϕs...)) )'[:]  # to reduce the computation time; [:] for vectorisation
-        # w .= pinv(hcat(-Δϕs...)') * hcat(∫rs...)'  # least square sense
-        update_index!(irl)
+        w_new = ( hcat(∫rs...) * pinv(hcat(-Δϕs...)) )'[:]  # to reduce the computation time; [:] for vectorisation
+        if !irl.stopped
+            if is_stopped(sc, w, w_new)
+                irl.stopped = true
+            else
+                w .= w_new
+                update_index!(irl)
+            end
+        end
     end
 end
 

--- a/src/irl/linear_irl.jl
+++ b/src/irl/linear_irl.jl
@@ -61,7 +61,7 @@ function evaluate_policy!(irl::LinearIRL, buffer::DataBuffer, w,
     @unpack i, N = irl
     @unpack data_array = buffer
     data_filtered = filter(x -> x.i == i, data_array)  # data from the current policy
-    if length(data_filtered) >= N
+    if length(data_filtered) >= N + 1
         data_sorted = sort(data_filtered, by=x -> x.t)  # sort by time index
         ϕs_prev = data_sorted[end-N:end-1] |> Map(datum -> datum.ϕ) |> collect
         V̂s = data_sorted[end-(N-1):end] |> Map(datum -> datum.V̂) |> collect

--- a/src/irl/linear_irl.jl
+++ b/src/irl/linear_irl.jl
@@ -7,8 +7,6 @@ See [1, "IRL Optimal Adaptive Control Using Value Iteration"].
 # Notes
 - T: Data stack period
 - N: The maximum length of stacked data
-- ϕs_prev: the vector of bases (evaluated)
-- V̂: the vector of approximate values (evaluated)
 """
 mutable struct LinearIRL <: AbstractIRL
     Q::AbstractMatrix

--- a/src/irl/linear_irl.jl
+++ b/src/irl/linear_irl.jl
@@ -7,6 +7,8 @@ See [1, "IRL Optimal Adaptive Control Using Value Iteration"].
 # Notes
 - T: Data stack period
 - N: The maximum length of stacked data
+- ϕs_prev: the vector of bases (evaluated)
+- V̂: the vector of approximate values (evaluated)
 """
 mutable struct LinearIRL <: AbstractIRL
     Q::AbstractMatrix
@@ -30,6 +32,14 @@ mutable struct LinearIRL <: AbstractIRL
             @assert N >= N_min
         end
         @assert T > 0 && N > 0
+        n1, n2 = size(Q)
+        @assert n1 == n2
+        N_min = n1*(n1 + 1)/2
+        if N == nothing
+            N = N_min
+        else
+            @assert N >= N_min
+        end
         R_inv = inv(R)
         i = i_init
         new(Q, R_inv, B, T, N, i, i_init)

--- a/src/irl/linear_irl.jl
+++ b/src/irl/linear_irl.jl
@@ -69,11 +69,31 @@ function value_iteration!(irl::LinearIRL, buffer::DataBuffer, w)
         P = convert_to_matrix(w)
         V̂s_with_prev_P = xs |> Map(x -> value(irl, P, x)) |> collect
         V̂s = ∫rs .+ V̂s_with_prev_P
-        irl.i += 1  # update iteration number
         # update the critic parameter
         w .= ( hcat(V̂s...) * pinv(hcat(ϕs_prev...)) )'[:]  # to reduce the computation time; [:] for vectorisation
         # w .= pinv(hcat(ϕs_prev...)') * hcat(V̂s...)'  # least square sense
+        update_index!(irl)
     end
+end
+
+function policy_iteration!(irl::LinearIRL, buffer::DataBuffer, w)
+    @unpack i, N = irl
+    @unpack data_array = buffer
+    data_filtered = filter(x -> x.i == i, data_array)  # data from the current policy
+    if length(data_filtered) >= N + 1
+        data_sorted = sort(data_filtered, by=x -> x.t)  # sort by time index
+        ϕs_prev_and_present = data_sorted[end-N:end] |> Map(datum -> datum.ϕ) |> collect
+        Δϕs = diff(ϕs_prev_and_present)
+        ∫rs = data_sorted[end-(N-1):end] |> Map(datum -> datum.∫r) |> collect
+        # update the critic parameter
+        w .= ( hcat(∫rs...) * pinv(hcat(-Δϕs...)) )'[:]  # to reduce the computation time; [:] for vectorisation
+        # w .= pinv(hcat(-Δϕs...)') * hcat(∫rs...)'  # least square sense
+        update_index!(irl)
+    end
+end
+
+function update_index!(irl::LinearIRL)
+    irl.i += 1
 end
 
 """

--- a/src/irl/linear_irl.jl
+++ b/src/irl/linear_irl.jl
@@ -1,5 +1,5 @@
 """
-See [1, "IRL Optimal Adaptive Control Using Value Iteration"].
+See [1, "Online Implementation of IRL: A Hybrid Optimal Adaptive Controller"].
 
 # Refs
 [1] “Reinforcement Learning and Feedback Control: Using Natural Decision Methods to Design Optimal Adaptive Controllers,” IEEE Control Syst., vol. 32, no. 6, pp. 76–105, Dec. 2012, doi: 10.1109/MCS.2012.2214134.
@@ -76,6 +76,13 @@ function value_iteration!(irl::LinearIRL, buffer::DataBuffer, w)
     end
 end
 
+"""
+Policy iteration [1, Eq. 98]; updated in least-square sense
+# Notes
+w: critic parameter (vectorised)
+- Δϕs: the vector of (ϕ - ϕ_prev) (evaluated)
+- ∫rs: the vector of integral running cost by numerical integration (evaluated)
+"""
 function policy_iteration!(irl::LinearIRL, buffer::DataBuffer, w)
     @unpack i, N = irl
     @unpack data_array = buffer

--- a/src/utils/stop_conditions/stop_conditions.jl
+++ b/src/utils/stop_conditions/stop_conditions.jl
@@ -1,0 +1,20 @@
+abstract type AbstractStopCondition end
+
+function is_stopped(sc::AbstractStopCondition, args...; kwrags...)
+    error("Defined this method for type: $(typeof(sc))")
+end
+
+
+struct DistanceStopCondition <: AbstractStopCondition
+    eps::Real
+    p::Real
+    function DistanceStopCondition(eps=1e-3, p=2)
+        @assert p > 1
+        new(p, eps)
+    end
+end
+
+function is_stopped(sc::DistanceStopCondition, w, w_new)
+    @unpack eps, p = sc
+    norm(w_new - w, p) < eps
+end

--- a/src/utils/stop_conditions/stop_conditions.jl
+++ b/src/utils/stop_conditions/stop_conditions.jl
@@ -8,7 +8,7 @@ end
 struct DistanceStopCondition <: AbstractStopCondition
     eps::Real
     p::Real
-    function DistanceStopCondition(eps=1e-3, p=2)
+    function DistanceStopCondition(eps=1e-1, p=2)
         @assert p > 1
         new(p, eps)
     end

--- a/src/utils/stop_conditions/stop_conditions.jl
+++ b/src/utils/stop_conditions/stop_conditions.jl
@@ -1,6 +1,6 @@
 abstract type AbstractStopCondition end
 
-function is_stopped(sc::AbstractStopCondition, args...; kwrags...)
+function is_terminated(sc::AbstractStopCondition, args...; kwrags...)
     error("Defined this method for type: $(typeof(sc))")
 end
 
@@ -14,7 +14,7 @@ struct DistanceStopCondition <: AbstractStopCondition
     end
 end
 
-function is_stopped(sc::DistanceStopCondition, w, w_new)
+function is_terminated(sc::DistanceStopCondition, w, w_new)
     @unpack eps, p = sc
     norm(w_new - w, p) < eps
 end

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -1,3 +1,4 @@
 include("convert.jl")
 include("data_buffer.jl")
 include("cost/cost.jl")
+include("stop_conditions/stop_conditions.jl")

--- a/test/irl/irl.jl
+++ b/test/irl/irl.jl
@@ -30,7 +30,8 @@ using LinearAlgebra
         @test length(buffer.data_array) == length(ts)
         ŵ_new = deepcopy(ŵ)
         i = deepcopy(irl.i)
-        DataDrivenControl.evaluate_policy!(irl, buffer, ŵ_new)
+        DataDrivenControl.policy_iteration!(irl, buffer, ŵ_new)
+        DataDrivenControl.value_iteration!(irl, buffer, ŵ_new)
         @test ŵ_new != ŵ  # updated?
         @test i + 1 == irl.i
         DataDrivenControl.reset!(irl)


### PR DESCRIPTION
~~동역학을 돌리기 위한 스크립트 예제를 작성했습니다.~~ Resolves #10, #19.

# Notes
- [x] @hnlee77 [#16, comment](https://github.com/fdcl-data-driven-control/DataDrivenControl.jl/issues/16#issuecomment-1003424254) 의 질문대로, 현재 이 PR 은 [1] 에서 언급한 VI 를 구현한 것이나 (식 (99), (96)), 아직 이에 대한 수렴성 분석을 찾지 못함. [2] 의 PI 는 [1] 의 식 (98), (96) 에 대응함. ~~이에 맞추어 코드를 변경해야할지 결정해야함 (또한, 만일 VI 와 PI 가 구분된다면 이름을 `LinearIRL` 에서 `LinearVIIRL` 등으로 바꾸어야할듯)~~
    - `value_iteration!` 추가됨
    - `policy_iteration!` 추가됨
- [x] Stop condition 추가 #19

# Summary
~~아직 linear IRL 로 업데이트한 것은 아니고, [1, example 2] 의 예제 시스템을 구현하고 확인한 것입니다.~~ [1, example 2] 의 예제를 구현함.
~~향후~~ linear IRL 의 업데이트를 ~~[DiscreteCallback](https://diffeq.sciml.ai/stable/features/callback_functions/#DiscreteCallback-Examples)~~ [PeriodicCallback](https://diffeq.sciml.ai/stable/features/callback_library/#PeriodicCallback) 을 이용해서 적용함.~~하면 될 것으로 보입니다.~~

아래 그림은 파라미터를 논문 상의 최적값에 perturbation 을 초기값으로 한 response 입니다 (검은 선은 최적값).
참고로 동일 시드로 맞추거나 한 것은 아님.
업데이트 기법은 `value_iteration!` 을 쓰거나, `policy_iteration!` 을 써서 할 수 있음:
```julia
            value_iteration!(controller, buffer, w)
            # policy_iteration!(controller, buffer, w)
```

- value iteration: 천천히 수렴하는 경향을 보임; stop condition 에 크게 영향을 받지 않음
![image](https://user-images.githubusercontent.com/43136096/147917214-81f52bb9-26ff-4e90-babd-85ffd89494b2.png)

- policy iteration: 빠르게 수렴하는 경향을 보임; stop condition 이 적절하지 않을 경우, 파라미터가 자주 변하는 것을 관찰함
![image](https://user-images.githubusercontent.com/43136096/147917236-7eb0a6b8-b5e1-4851-bb68-4b9d451f0251.png)


# Notes
- 몇 가지 주로 쓰일만한 함수를 export 시켰습니다.
- #14 에서 이어짐

# Refs
[1] “Reinforcement Learning and Feedback Control: Using Natural Decision Methods to Design Optimal Adaptive Controllers,” IEEE Control Syst., vol. 32, no. 6, pp. 76–105, Dec. 2012, doi: 10.1109/MCS.2012.2214134.
[2] D. Vrabie, O. Pastravanu, M. Abu-Khalaf, and F. L. Lewis, “Adaptive Optimal Control for Continuous-Time Linear Systems Based on Policy Iteration,” Automatica, vol. 45, no. 2, pp. 477–484, Feb. 2009, doi: 10.1016/j.automatica.2008.08.017.